### PR TITLE
Dereference fix

### DIFF
--- a/yemba.yy.c
+++ b/yemba.yy.c
@@ -1435,6 +1435,12 @@ static void yy_load_buffer_state  (void)
 {
 	int oerrno = errno;
     
+	if (b == NULL) {
+        /* Handle the case where b is NULL */
+        fprintf(stderr, "yy_init_buffer: Invalid buffer state.\n");
+        return;
+    }
+	
 	yy_flush_buffer( b );
 
 	b->yy_input_file = file;


### PR DESCRIPTION
Fixed: 
- Before accessing members of `b`, we first check if `b` is `NULL`. This prevents potential null pointer dereference issues and ensures that if `b` is `NULL`, the function safely exits with an appropriate message.

```
Checking yemba.yy.c ...
yemba.yy.c:1440:2: warning: Possible null pointer dereference: b [nullPointer]
 b->yy_input_file = file;
 ^
yemba.yy.c:1333:18: note: Calling function 'yy_init_buffer', 1st argument '(yy_buffer_stack)?(yy_buffer_stack)[yy_buffer_stack_top]:NULL' value is 0
 yy_init_buffer( YY_CURRENT_BUFFER, input_file );
                 ^
yemba.yy.c:1440:2: note: Null pointer dereference
 b->yy_input_file = file;
 ^
yemba.yy.c:1441:2: warning: Possible null pointer dereference: b [nullPointer]
 b->yy_fill_buffer = 1;
 ^
yemba.yy.c:1333:18: note: Calling function 'yy_init_buffer', 1st argument '(yy_buffer_stack)?(yy_buffer_stack)[yy_buffer_stack_top]:NULL' value is 0
 yy_init_buffer( YY_CURRENT_BUFFER, input_file );
                 ^
yemba.yy.c:1441:2: note: Null pointer dereference
 b->yy_fill_buffer = 1;
 ^
```